### PR TITLE
Fix installation hint in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Uses data from https://github.com/AliasIO/wappalyzer
 
 ### Using *go install*
 
-```
-go install github.com/projectdiscovery/wappalyzergo/cmd/update-fingerprints
+```sh
+go install -v github.com/projectdiscovery/wappalyzergo/cmd/update-fingerprints@latest
 ```
 
 After this command *wappalyzergo* library source will be in your current go.mod.


### PR DESCRIPTION
Current version:

```sh
➜ go install github.com/projectdiscovery/wappalyzergo/cmd/update-fingerprints

go: 'go install' requires a version when current directory is not in a module
Try 'go install github.com/projectdiscovery/wappalyzergo/cmd/update-fingerprints@latest' to install the latest version
```

New version:

```sh
➜ go install -v github.com/projectdiscovery/wappalyzergo/cmd/update-fingerprints@latest

go: downloading github.com/projectdiscovery/wappalyzergo v0.0.65
```