### PR TITLE
Add FingerprintWithInfo method

### DIFF
--- a/cmd/update-fingerprints/main.go
+++ b/cmd/update-fingerprints/main.go
@@ -14,9 +14,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 )
 
-var (
-	fingerprints = flag.String("fingerprints", "../../fingerprints_data.json", "File to write wappalyzer fingerprints to")
-)
+var fingerprints = flag.String("fingerprints", "../../fingerprints_data.json", "File to write wappalyzer fingerprints to")
 
 // Fingerprints contains a map of fingerprints for tech detection
 type Fingerprints struct {
@@ -26,14 +24,16 @@ type Fingerprints struct {
 
 // Fingerprint is a single piece of information about a tech
 type Fingerprint struct {
-	CSS     interface{}            `json:"css"`
-	Cookies map[string]string      `json:"cookies"`
-	JS      map[string]string      `json:"js"`
-	Headers map[string]string      `json:"headers"`
-	HTML    interface{}            `json:"html"`
-	Script  interface{}            `json:"script"`
-	Meta    map[string]interface{} `json:"meta"`
-	Implies interface{}            `json:"implies"`
+	CSS         interface{}            `json:"css"`
+	Cookies     map[string]string      `json:"cookies"`
+	JS          map[string]string      `json:"js"`
+	Headers     map[string]string      `json:"headers"`
+	HTML        interface{}            `json:"html"`
+	Script      interface{}            `json:"script"`
+	Meta        map[string]interface{} `json:"meta"`
+	Implies     interface{}            `json:"implies"`
+	Description string                 `json:"description"`
+	Website     string                 `json:"website"`
 }
 
 // OutputFingerprints contains a map of fingerprints for tech detection
@@ -45,14 +45,16 @@ type OutputFingerprints struct {
 
 // OutputFingerprint is a single piece of information about a tech validated and normalized
 type OutputFingerprint struct {
-	Cookies map[string]string   `json:"cookies,omitempty"`
-	JS      []string            `json:"js,omitempty"`
-	Headers map[string]string   `json:"headers,omitempty"`
-	HTML    []string            `json:"html,omitempty"`
-	Script  []string            `json:"script,omitempty"`
-	CSS     []string            `json:"css,omitempty"`
-	Meta    map[string][]string `json:"meta,omitempty"`
-	Implies []string            `json:"implies,omitempty"`
+	Cookies     map[string]string   `json:"cookies,omitempty"`
+	JS          []string            `json:"js,omitempty"`
+	Headers     map[string]string   `json:"headers,omitempty"`
+	HTML        []string            `json:"html,omitempty"`
+	Script      []string            `json:"script,omitempty"`
+	CSS         []string            `json:"css,omitempty"`
+	Meta        map[string][]string `json:"meta,omitempty"`
+	Implies     []string            `json:"implies,omitempty"`
+	Description string              `json:"description,omitempty"`
+	Website     string              `json:"website,omitempty"`
 }
 
 const fingerprintURL = "https://raw.githubusercontent.com/AliasIO/wappalyzer/master/src/technologies/%s.json"
@@ -60,7 +62,7 @@ const fingerprintURL = "https://raw.githubusercontent.com/AliasIO/wappalyzer/mas
 func makeFingerprintURLs() []string {
 	files := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "_"}
 
-	var fingerprints []string
+	fingerprints := make([]string, 0, len(files))
 	for _, item := range files {
 		fingerprints = append(fingerprints, fmt.Sprintf(fingerprintURL, item))
 	}
@@ -88,7 +90,7 @@ func main() {
 
 	log.Printf("Got %d valid fingerprints\n", len(outputFingerprints.Apps))
 
-	fingerprintsFile, err := os.OpenFile(*fingerprints, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	fingerprintsFile, err := os.OpenFile(*fingerprints, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o666)
 	if err != nil {
 		log.Fatalf("Could not open fingerprints file %s: %s\n", *fingerprints, err)
 	}
@@ -135,9 +137,11 @@ func normalizeFingerprints(fingerprints *Fingerprints) *OutputFingerprints {
 
 	for app, fingerprint := range fingerprints.Apps {
 		output := OutputFingerprint{
-			Cookies: make(map[string]string),
-			Headers: make(map[string]string),
-			Meta:    make(map[string][]string),
+			Cookies:     make(map[string]string),
+			Headers:     make(map[string]string),
+			Meta:        make(map[string][]string),
+			Description: fingerprint.Description,
+			Website:     fingerprint.Website,
 		}
 
 		for cookie, value := range fingerprint.Cookies {

--- a/fingerprints.go
+++ b/fingerprints.go
@@ -15,14 +15,16 @@ type Fingerprints struct {
 
 // Fingerprint is a single piece of information about a tech validated and normalized
 type Fingerprint struct {
-	Cookies map[string]string   `json:"cookies"`
-	JS      []string            `json:"js"`
-	Headers map[string]string   `json:"headers"`
-	HTML    []string            `json:"html"`
-	CSS     []string            `json:"css"`
-	Script  []string            `json:"scripts"`
-	Meta    map[string][]string `json:"meta"`
-	Implies []string            `json:"implies"`
+	Cookies     map[string]string   `json:"cookies"`
+	JS          []string            `json:"js"`
+	Headers     map[string]string   `json:"headers"`
+	HTML        []string            `json:"html"`
+	CSS         []string            `json:"css"`
+	Script      []string            `json:"scripts"`
+	Meta        map[string][]string `json:"meta"`
+	Implies     []string            `json:"implies"`
+	Description string              `json:"description"`
+	Website     string              `json:"website"`
 }
 
 // CompiledFingerprints contains a map of fingerprints for tech detection
@@ -35,6 +37,10 @@ type CompiledFingerprints struct {
 type CompiledFingerprint struct {
 	// implies contains technologies that are implicit with this tech
 	implies []string
+	// description contains fingerprint description
+	description string
+	// website contains a URL associated with the fingerprint
+	website string
 	// cookies contains fingerprints for target cookies
 	cookies map[string]*versionRegex
 	// js contains fingerprints for the js file
@@ -47,6 +53,12 @@ type CompiledFingerprint struct {
 	script []*versionRegex
 	// meta contains fingerprints for meta tags
 	meta map[string][]*versionRegex
+}
+
+// AppInfo contains basic information about an App.
+type AppInfo struct {
+	Description string
+	Website     string
 }
 
 type versionRegex struct {
@@ -118,13 +130,15 @@ const (
 // loadPatterns loads the fingerprint patterns and compiles regexes
 func compileFingerprint(fingerprint *Fingerprint) *CompiledFingerprint {
 	compiled := &CompiledFingerprint{
-		implies: fingerprint.Implies,
-		cookies: make(map[string]*versionRegex),
-		js:      make([]*versionRegex, 0, len(fingerprint.JS)),
-		headers: make(map[string]*versionRegex),
-		html:    make([]*versionRegex, 0, len(fingerprint.HTML)),
-		script:  make([]*versionRegex, 0, len(fingerprint.Script)),
-		meta:    make(map[string][]*versionRegex),
+		implies:     fingerprint.Implies,
+		description: fingerprint.Description,
+		website:     fingerprint.Website,
+		cookies:     make(map[string]*versionRegex),
+		js:          make([]*versionRegex, 0, len(fingerprint.JS)),
+		headers:     make(map[string]*versionRegex),
+		html:        make([]*versionRegex, 0, len(fingerprint.HTML)),
+		script:      make([]*versionRegex, 0, len(fingerprint.Script)),
+		meta:        make(map[string][]*versionRegex),
 	}
 
 	for header, pattern := range fingerprint.Cookies {

--- a/tech.go
+++ b/tech.go
@@ -160,3 +160,26 @@ func (s *Wappalyze) FingerprintWithTitle(headers map[string][]string, body []byt
 	}
 	return uniqueFingerprints.getValues(), ""
 }
+
+// FingerprintWithInfo identifies technologies on a target,
+// based on the received response headers and body.
+// It also returns basic information about the technology, such as description
+// and website URL.
+//
+// Body should not be mutated while this function is being called, or it may
+// lead to unexpected things.
+func (s *Wappalyze) FingerprintWithInfo(headers map[string][]string, body []byte) map[string]AppInfo {
+	apps := s.Fingerprint(headers, body)
+	result := make(map[string]AppInfo, len(apps))
+
+	for app := range apps {
+		if fingerprint, ok := s.fingerprints.Apps[app]; ok {
+			result[app] = AppInfo{
+				Description: fingerprint.description,
+				Website:     fingerprint.website,
+			}
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
Hi there!

This PR introduces a new `FingerprintWithInfo` method which returns a map similar to the `Fingerprint` and `FingerprintWithTitle` methods, with the difference that the map values are structs which, for now, contain description and website URL for the associated app/technology.

In order for this to work, I have extended the fingerprint structs to hold this information, as well as modified `update-fingerprints` to include this information from the raw Wappalyzer fingerprints when exporting.

**Please note** that `update-fingerprints` is, at the time of writing, failing with an error due to a [syntax error in one of the Wappalyzer JSON files](https://github.com/wappalyzer/wappalyzer/issues/7301). So, this is not caused by this change.

Thanks for maintaining this great package!