### PR TITLE
Resolving the missing reference to the technology fingerprints to the last snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A high performance port of the Wappalyzer Technology Detection Library to Go. Inspired by [Webanalyze](https://github.com/rverton/webanalyze).
 
-Uses data from https://github.com/AliasIO/wappalyzer
+Uses data from https://github.com/BBerastegui/wappalyzer-fingerprints
 
 ## Features
 

--- a/cmd/update-fingerprints/main.go
+++ b/cmd/update-fingerprints/main.go
@@ -57,7 +57,7 @@ type OutputFingerprint struct {
 	Website     string              `json:"website,omitempty"`
 }
 
-const fingerprintURL = "https://raw.githubusercontent.com/BBerastegui/wappalyzer/master/%s.json"
+const fingerprintURL = "https://raw.githubusercontent.com/BBerastegui/wappalyzer-fingerprints/master/%s.json"
 
 func makeFingerprintURLs() []string {
 	files := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "_"}

--- a/cmd/update-fingerprints/main.go
+++ b/cmd/update-fingerprints/main.go
@@ -57,7 +57,7 @@ type OutputFingerprint struct {
 	Website     string              `json:"website,omitempty"`
 }
 
-const fingerprintURL = "https://raw.githubusercontent.com/AliasIO/wappalyzer/master/src/technologies/%s.json"
+const fingerprintURL = "https://raw.githubusercontent.com/BBerastegui/wappalyzer/master/%s.json"
 
 func makeFingerprintURLs() []string {
 	files := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "_"}


### PR DESCRIPTION
As discussed here: https://github.com/projectdiscovery/wappalyzergo/issues/57

The repository where the fingerprints were pulled from has become private. I've just copied the fingerprints into a dedicated repository and referenced it accordingly.