### PR TITLE
Add Docker support for Go project

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,34 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/wappalyzergo:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Build the Go project
+FROM golang:1.21 as builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN go build -o main ./cmd/update-fingerprints
+
+# Create a minimal image
+FROM alpine:latest
+
+WORKDIR /root/
+
+COPY --from=builder /app/main .
+
+ENTRYPOINT ["./main"]

--- a/README.md
+++ b/README.md
@@ -47,3 +47,59 @@ func main() {
 	// Output: map[Acquia Cloud Platform:{} Amazon EC2:{} Apache:{} Cloudflare:{} Drupal:{} PHP:{} Percona:{} React:{} Varnish:{}]
 }
 ```
+
+## Docker
+
+### Building the Docker image
+
+To build the Docker image, run the following command:
+
+```sh
+docker build -t wappalyzergo .
+```
+
+### Running the Docker container
+
+To run the Docker container, use the following command:
+
+```sh
+docker run --rm -v $(pwd):/app wappalyzergo --fingerprints /app/fingerprints_data.json
+```
+
+### Using Docker Compose
+
+You can also use Docker Compose to build and run the Docker container. Create a `docker-compose.yml` file with the following content:
+
+```yaml
+version: '3.8'
+
+services:
+  wappalyzergo:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: ["./main"]
+    command: ["--fingerprints", "/app/fingerprints_data.json"]
+    volumes:
+      - .:/app
+```
+
+To build and run the Docker container using Docker Compose, run the following command:
+
+```sh
+docker-compose up --build
+```
+
+### Passing parameters to the Docker container
+
+You can pass parameters to the Docker container by appending them to the `docker run` or `docker-compose up` command. For example:
+
+```sh
+docker run --rm -v $(pwd):/app wappalyzergo --fingerprints /app/fingerprints_data.json --some-other-parameter value
+```
+
+or
+
+```sh
+docker-compose run wappalyzergo --some-other-parameter value
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  wappalyzergo:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: ["./main"]
+    command: ["--fingerprints", "/app/fingerprints_data.json"]
+    volumes:
+      - .:/app


### PR DESCRIPTION
Add Docker support for the Go project.

* **Dockerfile**
  - Create a Dockerfile to build the Go project using a multi-stage build.
  - Set the entrypoint to the main Go binary.

* **docker-compose.yml**
  - Create a docker-compose file to run the Docker container.
  - Define a service for the Go project and allow passing parameters to the container.

* **.github/workflows/docker-build.yml**
  - Create a GitHub Actions workflow to build and push the Docker image.
  - Trigger the workflow on push and pull request events.

* **README.md**
  - Add instructions for building and running the Docker container.
  - Include examples of passing parameters to the container and using Docker Compose.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/projectdiscovery/wappalyzergo?shareId=70e3ec7b-9403-4d82-aef7-761c9f1175bb).