### PR TITLE
Prevent Overwriting Detected Version in matchString Function

### DIFF
--- a/fingerprints.go
+++ b/fingerprints.go
@@ -226,7 +226,9 @@ func (f *CompiledFingerprints) matchString(data string, part part) []matchPartRe
 			for _, pattern := range fingerprint.js {
 				if valid, versionString := pattern.Evaluate(data); valid {
 					matched = true
-					version = versionString
+					if version == "" && versionString != "" {
+						version = versionString
+					}
 					confidence = pattern.Confidence
 				}
 			}
@@ -234,7 +236,9 @@ func (f *CompiledFingerprints) matchString(data string, part part) []matchPartRe
 			for _, pattern := range fingerprint.scriptSrc {
 				if valid, versionString := pattern.Evaluate(data); valid {
 					matched = true
-					version = versionString
+					if version == "" && versionString != "" {
+						version = versionString
+					}
 					confidence = pattern.Confidence
 				}
 			}
@@ -242,7 +246,9 @@ func (f *CompiledFingerprints) matchString(data string, part part) []matchPartRe
 			for _, pattern := range fingerprint.html {
 				if valid, versionString := pattern.Evaluate(data); valid {
 					matched = true
-					version = versionString
+					if version == "" && versionString != "" {
+						version = versionString
+					}
 					confidence = pattern.Confidence
 				}
 			}
@@ -290,7 +296,9 @@ func (f *CompiledFingerprints) matchKeyValueString(key, value string, part part)
 
 				if valid, versionString := pattern.Evaluate(value); valid {
 					matched = true
-					version = versionString
+					if version == "" && versionString != "" {
+						version = versionString
+					}
 					confidence = pattern.Confidence
 					break
 				}
@@ -303,7 +311,9 @@ func (f *CompiledFingerprints) matchKeyValueString(key, value string, part part)
 
 				if valid, versionString := pattern.Evaluate(value); valid {
 					matched = true
-					version = versionString
+					if version == "" && versionString != "" {
+						version = versionString
+					}
 					confidence = pattern.Confidence
 					break
 				}
@@ -317,7 +327,9 @@ func (f *CompiledFingerprints) matchKeyValueString(key, value string, part part)
 				for _, pattern := range patterns {
 					if valid, versionString := pattern.Evaluate(value); valid {
 						matched = true
-						version = versionString
+						if version == "" && versionString != "" {
+							version = versionString
+						}
 						confidence = pattern.Confidence
 						break
 					}
@@ -369,7 +381,9 @@ func (f *CompiledFingerprints) matchMapString(keyValue map[string]string, part p
 				}
 				if valid, versionString := pattern.Evaluate(value); valid {
 					matched = true
-					version = versionString
+					if version == "" && versionString != "" {
+						version = versionString
+					}
 					confidence = pattern.Confidence
 					break
 				}
@@ -383,7 +397,9 @@ func (f *CompiledFingerprints) matchMapString(keyValue map[string]string, part p
 
 				if valid, versionString := pattern.Evaluate(value); valid {
 					matched = true
-					version = versionString
+					if version == "" && versionString != "" {
+						version = versionString
+					}
 					confidence = pattern.Confidence
 					break
 				}
@@ -398,7 +414,9 @@ func (f *CompiledFingerprints) matchMapString(keyValue map[string]string, part p
 				for _, pattern := range patterns {
 					if valid, versionString := pattern.Evaluate(value); valid {
 						matched = true
-						version = versionString
+						if version == "" && versionString != "" {
+							version = versionString
+						}
 						confidence = pattern.Confidence
 						break
 					}


### PR DESCRIPTION
Previously, if a version was detected by an initial regex pattern, it could be overwritten by subsequent patterns that failed to extract a version. This resulted in the detected version being lost when multiple regex patterns were evaluated in a loop.

Closes https://github.com/projectdiscovery/wappalyzergo/issues/120


### Changes:
- Ensure that once a version is detected, it is not overwritten unless a new version is explicitly found.
- Added a condition (`if version == "" && versionString != ""`) to retain the first detected version.

### Example Issue:
In cases where a script source contains version information (e.g., `<script src=".../jquery/3.7.1/..."></script>`), the first regex pattern may correctly extract the version, but a subsequent pattern failing to match could overwrite it with an empty value.

### Impact:
- Prevents the detected version from being erased by later regex evaluations.
- Ensures accurate fingerprinting by keeping the first valid version found.

This fix improves reliability in detecting versions across multiple fingerprinting patterns.


