### PR TITLE
Add option to use latest fingerprints_data.json file

### DIFF
--- a/patterns.go
+++ b/patterns.go
@@ -32,11 +32,19 @@ func ParsePattern(pattern string) (*ParsedPattern, error) {
 			}
 			regexPattern := part
 
+			// save version capture groups
+			regexPattern = strings.ReplaceAll(regexPattern, `((?:\d+\.)+\d+)`, "__verCapOne__")
+			regexPattern = strings.ReplaceAll(regexPattern, `(\d+(?:\.\d+)+)`, "__verCapTwo__")
+
 			regexPattern = strings.ReplaceAll(regexPattern, "/", "\\/")
 			regexPattern = strings.ReplaceAll(regexPattern, "\\+", "__escapedPlus__")
 			regexPattern = strings.ReplaceAll(regexPattern, "+", "{1,250}")
 			regexPattern = strings.ReplaceAll(regexPattern, "*", "{0,250}")
 			regexPattern = strings.ReplaceAll(regexPattern, "__escapedPlus__", "\\+")
+
+			// restore version capture groups
+			regexPattern = strings.ReplaceAll(regexPattern, "__verCapOne__", `((?:\d{1,20}\.){1,20}\d{1,20})`)
+			regexPattern = strings.ReplaceAll(regexPattern, "__verCapTwo__", `(\d{1,20}(?:\.\d{1,20}){1,20})`)
 
 			var err error
 			p.regex, err = regexp.Compile("(?i)" + regexPattern)

--- a/patterns.go
+++ b/patterns.go
@@ -32,19 +32,11 @@ func ParsePattern(pattern string) (*ParsedPattern, error) {
 			}
 			regexPattern := part
 
-			// save version capture groups
-			regexPattern = strings.ReplaceAll(regexPattern, `((?:\d+\.)+\d+)`, "__verCapOne__")
-			regexPattern = strings.ReplaceAll(regexPattern, `(\d+(?:\.\d+)+)`, "__verCapTwo__")
-
 			regexPattern = strings.ReplaceAll(regexPattern, "/", "\\/")
 			regexPattern = strings.ReplaceAll(regexPattern, "\\+", "__escapedPlus__")
 			regexPattern = strings.ReplaceAll(regexPattern, "+", "{1,250}")
 			regexPattern = strings.ReplaceAll(regexPattern, "*", "{0,250}")
 			regexPattern = strings.ReplaceAll(regexPattern, "__escapedPlus__", "\\+")
-
-			// restore version capture groups
-			regexPattern = strings.ReplaceAll(regexPattern, "__verCapOne__", `((?:\d{1,20}\.){1,20}\d{1,20})`)
-			regexPattern = strings.ReplaceAll(regexPattern, "__verCapTwo__", `(\d{1,20}(?:\.\d{1,20}){1,20})`)
 
 			var err error
 			p.regex, err = regexp.Compile("(?i)" + regexPattern)


### PR DESCRIPTION
I wanted the option to use the latest `fingerprints_data.json` in my applications without having to rebuild the binary with the latest embedded file. Taking #109 into account, I added an option to include the already-embedded file, as well as an option to overwrite the embedded signatures when the app name conflicted.

This is similar to #109 and takes its intentions into account. Where #109 would break existing uses of `New()`, this will not. It adds a new exported function for this specific use case, and one non-exported function for loading the file.

```golang
// NewFromFile creates a new tech detection instance from a file
// this allows using the latest fingerprints without recompiling the code
// loadEmbedded indicates whether to load the embedded fingerprints
// supersede indicates whether to overwrite the embedded fingerprints (if loaded) with the file fingerprints if the app name conflicts
// supersede is only used if loadEmbedded is true
func NewFromFile(filePath string, loadEmbedded, supersede bool) (*Wappalyze, error) {
...
}
```
```golang
wappalyzer.NewFromFile("fingerprints_data.json", false, false)
```

This allows a user to combine the embedded file with their own custom signatures, or use only their custom signatures. If the user's signatures include one or more app name that is included in the embedded signatures, they can optionally overwrite the embedded version with their custom version with the `supersede` flag. (this could be changed to `overwrite` as well)


