### PR TITLE
Iterate over all fingerprint patterns, fixes #138

### DIFF
--- a/fingerprints.go
+++ b/fingerprints.go
@@ -218,38 +218,44 @@ func (f *CompiledFingerprints) matchString(data string, part part) []matchPartRe
 	var technologies []matchPartResult
 
 	for app, fingerprint := range f.Apps {
-		var confidences []int
-		var versions []string
+		var version string
+		var confidence int
 
 		switch part {
 		case jsPart:
 			for _, pattern := range fingerprint.js {
 				if valid, versionString := pattern.Evaluate(data); valid {
 					matched = true
-					if versionString != "" {
-						versions = append(versions, versionString)
+					if pattern.Confidence > confidence {
+						confidence = pattern.Confidence
 					}
-					confidences = append(confidences, pattern.Confidence)
+					if versionString != "" && (version == "" || isMoreSpecific(versionString, version)) {
+						version = versionString
+					}
 				}
 			}
 		case scriptPart:
 			for _, pattern := range fingerprint.scriptSrc {
 				if valid, versionString := pattern.Evaluate(data); valid {
 					matched = true
-					if versionString != "" {
-						versions = append(versions, versionString)
+					if pattern.Confidence > confidence {
+						confidence = pattern.Confidence
 					}
-					confidences = append(confidences, pattern.Confidence)
+					if versionString != "" && (version == "" || isMoreSpecific(versionString, version)) {
+						version = versionString
+					}
 				}
 			}
 		case htmlPart:
 			for _, pattern := range fingerprint.html {
 				if valid, versionString := pattern.Evaluate(data); valid {
 					matched = true
-					if versionString != "" {
-						versions = append(versions, versionString)
+					if pattern.Confidence > confidence {
+						confidence = pattern.Confidence
 					}
-					confidences = append(confidences, pattern.Confidence)
+					if versionString != "" && (version == "" || isMoreSpecific(versionString, version)) {
+						version = versionString
+					}
 				}
 			}
 		}
@@ -257,12 +263,6 @@ func (f *CompiledFingerprints) matchString(data string, part part) []matchPartRe
 		// If no match, continue with the next fingerprint
 		if !matched {
 			continue
-		}
-
-		version := Lowest(versions)
-		confidence := 100
-		if len(confidences) > 0 {
-			confidence = Max(confidences)
 		}
 
 		// Append the technologies as well as implied ones
@@ -290,8 +290,8 @@ func (f *CompiledFingerprints) matchKeyValueString(key, value string, part part)
 	var technologies []matchPartResult
 
 	for app, fingerprint := range f.Apps {
-		var confidences []int
-		var versions []string
+		var version string
+		var confidence int
 
 		switch part {
 		case cookiesPart:
@@ -302,10 +302,12 @@ func (f *CompiledFingerprints) matchKeyValueString(key, value string, part part)
 
 				if valid, versionString := pattern.Evaluate(value); valid {
 					matched = true
-					if versionString != "" {
-						versions = append(versions, versionString)
+					if pattern.Confidence > confidence {
+						confidence = pattern.Confidence
 					}
-					confidences = append(confidences, pattern.Confidence)
+					if versionString != "" && (version == "" || isMoreSpecific(versionString, version)) {
+						version = versionString
+					}
 				}
 			}
 		case headersPart:
@@ -316,10 +318,12 @@ func (f *CompiledFingerprints) matchKeyValueString(key, value string, part part)
 
 				if valid, versionString := pattern.Evaluate(value); valid {
 					matched = true
-					if versionString != "" {
-						versions = append(versions, versionString)
+					if pattern.Confidence > confidence {
+						confidence = pattern.Confidence
 					}
-					confidences = append(confidences, pattern.Confidence)
+					if versionString != "" && (version == "" || isMoreSpecific(versionString, version)) {
+						version = versionString
+					}
 				}
 			}
 		case metaPart:
@@ -331,10 +335,12 @@ func (f *CompiledFingerprints) matchKeyValueString(key, value string, part part)
 				for _, pattern := range patterns {
 					if valid, versionString := pattern.Evaluate(value); valid {
 						matched = true
-						if versionString != "" {
-							versions = append(versions, versionString)
+						if pattern.Confidence > confidence {
+							confidence = pattern.Confidence
 						}
-						confidences = append(confidences, pattern.Confidence)
+						if versionString != "" && (version == "" || isMoreSpecific(versionString, version)) {
+							version = versionString
+						}
 					}
 				}
 			}
@@ -343,12 +349,6 @@ func (f *CompiledFingerprints) matchKeyValueString(key, value string, part part)
 		// If no match, continue with the next fingerprint
 		if !matched {
 			continue
-		}
-
-		version := Lowest(versions)
-		confidence := 100
-		if len(confidences) > 0 {
-			confidence = Max(confidences)
 		}
 
 		technologies = append(technologies, matchPartResult{
@@ -375,8 +375,8 @@ func (f *CompiledFingerprints) matchMapString(keyValue map[string]string, part p
 	var technologies []matchPartResult
 
 	for app, fingerprint := range f.Apps {
-		var confidences []int
-		var versions []string
+		var version string
+		var confidence int
 
 		switch part {
 		case cookiesPart:
@@ -387,13 +387,16 @@ func (f *CompiledFingerprints) matchMapString(keyValue map[string]string, part p
 				}
 				if pattern == nil {
 					matched = true
+					continue
 				}
 				if valid, versionString := pattern.Evaluate(value); valid {
 					matched = true
-					if versionString != "" {
-						versions = append(versions, versionString)
+					if pattern.Confidence > confidence {
+						confidence = pattern.Confidence
 					}
-					confidences = append(confidences, pattern.Confidence)
+					if versionString != "" && (version == "" || isMoreSpecific(versionString, version)) {
+						version = versionString
+					}
 				}
 			}
 		case headersPart:
@@ -405,10 +408,12 @@ func (f *CompiledFingerprints) matchMapString(keyValue map[string]string, part p
 
 				if valid, versionString := pattern.Evaluate(value); valid {
 					matched = true
-					if versionString != "" {
-						versions = append(versions, versionString)
+					if pattern.Confidence > confidence {
+						confidence = pattern.Confidence
 					}
-					confidences = append(confidences, pattern.Confidence)
+					if versionString != "" && (version == "" || isMoreSpecific(versionString, version)) {
+						version = versionString
+					}
 				}
 			}
 		case metaPart:
@@ -421,10 +426,12 @@ func (f *CompiledFingerprints) matchMapString(keyValue map[string]string, part p
 				for _, pattern := range patterns {
 					if valid, versionString := pattern.Evaluate(value); valid {
 						matched = true
-						if versionString != "" {
-							versions = append(versions, versionString)
+						if pattern.Confidence > confidence {
+							confidence = pattern.Confidence
 						}
-						confidences = append(confidences, pattern.Confidence)
+						if versionString != "" && (version == "" || isMoreSpecific(versionString, version)) {
+							version = versionString
+						}
 					}
 				}
 			}
@@ -433,12 +440,6 @@ func (f *CompiledFingerprints) matchMapString(keyValue map[string]string, part p
 		// If no match, continue with the next fingerprint
 		if !matched {
 			continue
-		}
-
-		version := Lowest(versions)
-		confidence := 100
-		if len(confidences) > 0 {
-			confidence = Max(confidences)
 		}
 
 		technologies = append(technologies, matchPartResult{
@@ -464,19 +465,6 @@ func FormatAppVersion(app, version string) string {
 		return app
 	}
 	return fmt.Sprintf("%s:%s", app, version)
-}
-
-func Max(arr []int) int {
-	if len(arr) == 0 {
-		panic("Max requires at least one argument")
-	}
-	m := arr[0]
-	for _, v := range arr[1:] {
-		if v > m {
-			m = v
-		}
-	}
-	return m
 }
 
 // GetFingerprints returns the fingerprint string from wappalyzer

--- a/versions.go
+++ b/versions.go
@@ -5,21 +5,16 @@ import (
 	"strings"
 )
 
-// Lowest returns the lowest version from a slice of version strings.
-// Supports colon- and dot-separated numeric versions (e.g. "1:2:0" or "1.2.0").
-// Non-numeric segments are treated as zero. If no valid version is found,
-// it returns the empty string.
-func Lowest(versions []string) string {
-	var lowest string
-	for _, v := range versions {
-		if v == "" {
-			continue // skip blank entries
-		}
-		if lowest == "" || versionLess(v, lowest) {
-			lowest = v
-		}
+// isMoreSpecific reports whether version a is more specific than version b.
+// A version with more segments is considered more specific (e.g. "3.6.0" over "3").
+// When segment counts are equal, the numerically higher version wins.
+func isMoreSpecific(a, b string) bool {
+	aParts := splitParts(a)
+	bParts := splitParts(b)
+	if len(aParts) != len(bParts) {
+		return len(aParts) > len(bParts)
 	}
-	return lowest
+	return versionLess(b, a)
 }
 
 // versionLess reports whether version a < version b.
@@ -27,12 +22,11 @@ func versionLess(a, b string) bool {
 	aParts := splitParts(a)
 	bParts := splitParts(b)
 
-	// Compare segment by segment
-	max := len(aParts)
-	if len(bParts) > max {
-		max = len(bParts)
+	maxLen := len(aParts)
+	if len(bParts) > maxLen {
+		maxLen = len(bParts)
 	}
-	for i := 0; i < max; i++ {
+	for i := 0; i < maxLen; i++ {
 		ai := 0
 		bi := 0
 		if i < len(aParts) {
@@ -48,22 +42,19 @@ func versionLess(a, b string) bool {
 			return false
 		}
 	}
-	// they are equal
 	return false
 }
 
-// splitParts splits v on ':' or '.' and parses each piece as an integer.
-// Non‑numeric or empty pieces become zero.
+// splitParts splits v on '.' and parses each piece as an integer.
+// Non-numeric or empty pieces become zero.
 func splitParts(v string) []int {
 	fields := strings.FieldsFunc(v, func(r rune) bool {
-		return r == ':' || r == '.'
+		return r == '.'
 	})
 	parts := make([]int, len(fields))
 	for i, f := range fields {
 		if n, err := strconv.Atoi(f); err == nil {
 			parts[i] = n
-		} else {
-			parts[i] = 0
 		}
 	}
 	return parts

--- a/versions_test.go
+++ b/versions_test.go
@@ -1,0 +1,83 @@
+package wappalyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitParts(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []int
+	}{
+		{"1.2.3", []int{1, 2, 3}},
+		{"10.0.1", []int{10, 0, 1}},
+		{"3", []int{3}},
+		{"", []int{}},
+		{"abc", []int{0}},
+		{"1.2.beta", []int{1, 2, 0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			require.Equal(t, tt.expected, splitParts(tt.input))
+		})
+	}
+}
+
+func TestVersionLess(t *testing.T) {
+	tests := []struct {
+		a, b     string
+		expected bool
+	}{
+		{"1.0.0", "2.0.0", true},
+		{"2.0.0", "1.0.0", false},
+		{"1.0.0", "1.0.0", false},
+		{"1.0.0", "1.0.1", true},
+		{"3", "3.6.0", true},
+		{"3.6.0", "3", false},
+		{"1.2", "1.10", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			require.Equal(t, tt.expected, versionLess(tt.a, tt.b))
+		})
+	}
+}
+
+func TestIsMoreSpecific(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     string
+		expected bool
+	}{
+		{"more segments wins", "3.6.0", "3", true},
+		{"fewer segments loses", "3", "3.6.0", false},
+		{"same segments higher wins", "3.6.0", "3.5.0", true},
+		{"same segments lower loses", "3.5.0", "3.6.0", false},
+		{"equal versions", "1.2.3", "1.2.3", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, isMoreSpecific(tt.a, tt.b))
+		})
+	}
+}
+
+func TestVersionSelectionInFingerprinting(t *testing.T) {
+	wappalyzer, err := New()
+	require.NoError(t, err)
+
+	t.Run("deterministic header version", func(t *testing.T) {
+		var results []map[string]struct{}
+		for i := 0; i < 20; i++ {
+			matches := wappalyzer.Fingerprint(map[string][]string{
+				"Server": {"Apache/2.4.29"},
+			}, []byte(""))
+			results = append(results, matches)
+		}
+		for i := 1; i < len(results); i++ {
+			require.Equal(t, results[0], results[i], "fingerprinting should be deterministic across runs")
+		}
+	})
+}


### PR DESCRIPTION
Until now, `matchKeyValueString` and `matchMapString` iterated over fingerprint patterns in non deterministic order because some parsed fingerprint patterns (for example headers) are parsed into a `map` type. Since also these functions iterated over patterns until a first match, it could return different version upon each run (described in issue #138).

With this change:

* There is a deterministic behavior because always all patterns are checked.
* There isn't a right way to choose a final version from a list of discovered versions IMO. I decided to use the lowest found because I think that one in theory poses the biggest security risk.
* From a list of found `confidences`, I choose a maximum value because from my understanding of the rest of the code any non-zero confidence value automatically flags the discovery as valid anyway.